### PR TITLE
fix(station): corrected SDk to SDK

### DIFF
--- a/handlers/poison_messages.go
+++ b/handlers/poison_messages.go
@@ -31,7 +31,7 @@ import (
 
 type PoisonMessagesHandler struct{}
 
-const invalidHeaderErrMessage string = "Missing mandatory message headers, please upgrade the SDK version you are using"
+const invalidPoisonHeaderErrMessage string = "Missing mandatory message headers, please upgrade the SDK version you are using"
 
 func (pmh PoisonMessagesHandler) HandleNewMessage(msg *nats.Msg) {
 	var message map[string]interface{}
@@ -56,7 +56,7 @@ func (pmh PoisonMessagesHandler) HandleNewMessage(msg *nats.Msg) {
 	producedByHeader := poisonMessageContent.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: " + invalidHeaderErrMessage)
+		logger.Error("Error while getting notified about a poison message: " + invalidPoisonHeaderErrMessage)
 		return
 	}
 

--- a/handlers/poison_messages.go
+++ b/handlers/poison_messages.go
@@ -31,6 +31,8 @@ import (
 
 type PoisonMessagesHandler struct{}
 
+const invalidHeaderErrMessage string = "Missing mandatory message headers, please upgrade the SDK version you are using"
+
 func (pmh PoisonMessagesHandler) HandleNewMessage(msg *nats.Msg) {
 	var message map[string]interface{}
 	err := json.Unmarshal(msg.Data, &message)
@@ -54,7 +56,7 @@ func (pmh PoisonMessagesHandler) HandleNewMessage(msg *nats.Msg) {
 	producedByHeader := poisonMessageContent.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using")
+		logger.Error("Error while getting notified about a poison message: " + invalidHeaderErrMessage)
 		return
 	}
 

--- a/handlers/poison_messages.go
+++ b/handlers/poison_messages.go
@@ -54,7 +54,7 @@ func (pmh PoisonMessagesHandler) HandleNewMessage(msg *nats.Msg) {
 	producedByHeader := poisonMessageContent.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDk version you are using")
+		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using")
 		return
 	}
 

--- a/handlers/stations.go
+++ b/handlers/stations.go
@@ -595,8 +595,8 @@ func (sh StationsHandler) GetMessageDetails(c *gin.Context) {
 	producedByHeader := natsMsg.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: " + invalidHeaderErrMessage)
-		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: " + invalidHeaderErrMessage})
+		logger.Error("Error while getting notified about a poison message: " + invalidPoisonHeaderErrMessage)
+		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: " + invalidPoisonHeaderErrMessage})
 		return
 	}
 

--- a/handlers/stations.go
+++ b/handlers/stations.go
@@ -595,8 +595,8 @@ func (sh StationsHandler) GetMessageDetails(c *gin.Context) {
 	producedByHeader := natsMsg.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDk version you are using")
-		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDk version you are using"})
+		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using")
+		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using"})
 		return
 	}
 

--- a/handlers/stations.go
+++ b/handlers/stations.go
@@ -595,8 +595,8 @@ func (sh StationsHandler) GetMessageDetails(c *gin.Context) {
 	producedByHeader := natsMsg.Header.Get("producedBy")
 
 	if connectionIdHeader == "" || producedByHeader == "" {
-		logger.Error("Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using")
-		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: Missing mandatory message headers, please upgrade the SDK version you are using"})
+		logger.Error("Error while getting notified about a poison message: " + invalidHeaderErrMessage)
+		c.AbortWithStatusJSON(configuration.SHOWABLE_ERROR_STATUS_CODE, gin.H{"message": "Error while getting notified about a poison message: " + invalidHeaderErrMessage})
 		return
 	}
 


### PR DESCRIPTION
This is a fix for #252 in which I found instances of the word `SDk` and replaced with `SDK`. Please let me know if anything was missed in the contribution workflow. Thanks!