### PR TITLE
Hybrid logger gracefull stream creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,13 +97,13 @@ func runMemphis(s *server.Server) db.DbInstance {
 
 	dbInstance, err := db.InitializeDbConnection(s)
 	if err != nil {
-		s.Errorf("Failed initializing db connection:" + " " + err.Error())
+		s.Errorf("Failed initializing db connection: " + err.Error())
 		os.Exit(1)
 	}
 
 	err = analytics.InitializeAnalytics(dbInstance.Client)
 	if err != nil {
-		s.Errorf("Failed initializing analytics: " + " " + err.Error())
+		s.Errorf("Failed initializing analytics: " + err.Error())
 	}
 
 	s.InitializeMemphisHandlers(dbInstance)
@@ -111,7 +111,7 @@ func runMemphis(s *server.Server) db.DbInstance {
 
 	err = server.CreateRootUserOnFirstSystemLoad()
 	if err != nil {
-		s.Errorf("Failed to create root user: " + " " + err.Error())
+		s.Errorf("Failed to create root user: " + err.Error())
 		db.Close(dbInstance, s)
 		os.Exit(1)
 	}
@@ -120,7 +120,7 @@ func runMemphis(s *server.Server) db.DbInstance {
 	s.ListenForPoisonMessages()
 	err = s.ListenForZombieConnCheckRequests()
 	if err != nil {
-		s.Errorf("Failed subscribing for zombie conns check requests:" + " " + err.Error())
+		s.Errorf("Failed subscribing for zombie conns check requests: " + err.Error())
 		os.Exit(1)
 	}
 

--- a/server/log.go
+++ b/server/log.go
@@ -85,7 +85,14 @@ func (s *Server) ConfigureLogger() {
 		if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
 			colors = false
 		}
-		log, s.memphis.activateSysLogsPubFunc = srvlog.NewMemphisLogger(s.createMemphisLoggerFunc(), opts.Logtime, opts.Debug, opts.Trace, colors, true)
+		s.memphis.fallbackLogQ = s.newIPQueue("memphis_fallback_logs")
+		log, s.memphis.activateSysLogsPubFunc = srvlog.NewMemphisLogger(s.createMemphisLoggerFunc(),
+			s.createMemphisLoggerFallbackFunc(),
+			opts.Logtime,
+			opts.Debug,
+			opts.Trace,
+			colors,
+			true)
 	}
 
 	s.SetLoggerV2(log, opts.Debug, opts.Trace, opts.TraceVerbose)
@@ -253,11 +260,25 @@ func (s *Server) executeLogCall(f func(logger Logger, format string, v ...interf
 
 	f(s.logging.logger, format, args...)
 }
+func publishLogToSubjectAndAnalytics(s *Server, label string, log []byte) {
+	s.sendLogToSubject(label, log)
+	s.sendLogToAnalytics(label, log)
+}
 
 func (s *Server) createMemphisLoggerFunc() srvlog.HybridLogPublishFunc {
 	return func(label string, log []byte) {
-		s.sendLogToSubject(label, log)
-		s.sendLogToAnalytics(label, log)
+		publishLogToSubjectAndAnalytics(s, label, log)
+	}
+}
+
+type fallbackLog struct {
+	label string
+	log   []byte
+}
+
+func (s *Server) createMemphisLoggerFallbackFunc() srvlog.HybridLogPublishFunc {
+	return func(label string, log []byte) {
+		s.memphis.fallbackLogQ.push(fallbackLog{label: label, log: copyBytes(log)})
 	}
 }
 

--- a/server/memphis_handlers.go
+++ b/server/memphis_handlers.go
@@ -66,9 +66,9 @@ type srvMemphis struct {
 	dbCtx                  context.Context
 	dbCancel               context.CancelFunc
 	activateSysLogsPubFunc func()
+	fallbackLogQ           *ipQueue
 	mcrReported            bool
 	mcr                    chan struct{} // memphis cluster ready
-	logStreamCreated       bool
 	jsApiMu                sync.Mutex
 }
 
@@ -81,7 +81,6 @@ func (s *Server) InitializeMemphisHandlers(dbInstance db.DbInstance) {
 	s.memphis.serverID = configuration.SERVER_NAME
 	s.memphis.mcrReported = false
 	s.memphis.mcr = make(chan struct{})
-	s.memphis.logStreamCreated = false
 
 	usersCollection = db.GetCollection("users", dbInstance.Client)
 	imagesCollection = db.GetCollection("images", dbInstance.Client)


### PR DESCRIPTION
Changes to the logging mechanism:
1. Waiting indefinitely for cluster to be ready, if not ready in 2 minutes - write Error to logs.
2. until the publish activation, logs are gathered in a queue. once publish activation happens, all logs are dumped from the queue into the stream.
